### PR TITLE
Allow schema attributes of type 'object'

### DIFF
--- a/okta/resource_user_schema.go
+++ b/okta/resource_user_schema.go
@@ -36,8 +36,8 @@ func resourceUserSchema() *schema.Resource {
 			"type": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"string", "boolean", "number", "integer", "array"}, false),
-				Description:  "Subschema type: string, boolean, number, integer, or array",
+				ValidateFunc: validation.StringInSlice([]string{"string", "boolean", "number", "integer", "array", "object"}, false),
+				Description:  "Subschema type: string, boolean, number, integer, array, or object",
 				ForceNew:     true,
 			},
 			"array_type": &schema.Schema{


### PR DESCRIPTION
Allow schema attributes of type object, such as in the following example:

```
resource "okta_user_schema" "testschema" {
  index = "an_object"
  title = "My Complex Models"
  type = "object"
  description = "example object type attribute in schema"
  required = false
  master = "OKTA"
}
```